### PR TITLE
Patch: set default image version

### DIFF
--- a/charts/gophish/Chart.yaml
+++ b/charts/gophish/Chart.yaml
@@ -3,7 +3,7 @@ name: gophish
 description: gophish helm chart for Kubernetes
 type: application
 version: 1.2.14
-appVersion: 0.12.1
+appVersion: 0.12.2
 maintainers:
   - email: admin@josa.ngo
     name: JOSA

--- a/charts/gophish/values.yaml
+++ b/charts/gophish/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: josaorg/gophish
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "8d91c2f3c6c270eef8ed8b1855c827c081ac66cb"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Fixes an error described in issue #49

```
Failed to pull image "josaorg/gophish:0.12.1": failed to pull and unpack image "docker.io/josaorg/gophish:0.12.1": failed to resolve reference "docker.io/josaorg/gophish:0.12.1": unexpected status from HEAD request to https://www.docker.com/: 403 Forbidden
```