### PR TITLE
wazuh: Release version 2.3.2

### DIFF
--- a/charts/wazuh/Chart.yaml
+++ b/charts/wazuh/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.1
+version: 2.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.14.3"
+appVersion: "4.14.4"

--- a/charts/wazuh/templates/indexer/indexer-sts.yaml
+++ b/charts/wazuh/templates/indexer/indexer-sts.yaml
@@ -82,7 +82,7 @@ spec:
             - name: SECURITY_AUTHCZ_ADMIN_DN
               value: {{ .Values.tls.certManager.commonName }}
             - name: SECURITY_NODES_DN
-              value: {{ .Values.indexer.config.nodesDN | default (printf "*.%s" (include "wazuh.fullname" .)) }}
+              value: {{ (.Values.indexer.config.nodesDN | default (printf "*.%s" (include "wazuh.fullname" .))) | quote }}
             - name: KUBERNETES_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/wazuh/values.yaml
+++ b/charts/wazuh/values.yaml
@@ -50,7 +50,7 @@ indexer:
     repository: wazuh/wazuh-indexer
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "4.14.3"
+    tag: ""
 
   # Probe configurations
   # Note: Uses exec probe with curl
@@ -188,7 +188,7 @@ manager:
     repository: wazuh/wazuh-manager
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "4.14.3"
+    tag: ""
 
   # Priority class for the manager pods
   priorityClassName: ""
@@ -408,7 +408,7 @@ dashboard:
     repository: wazuh/wazuh-dashboard
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "4.14.3"
+    tag: ""
 
   config:
     ServerSSL: true


### PR DESCRIPTION
Bump appVersion to 4.14.4
Clear image tags for indexer, manager, and dashboard components from the default values.