### PR TITLE
Release monk chart 2.4.0 with listmonk v6.2.0

### DIFF
--- a/charts/monk/Chart.yaml
+++ b/charts/monk/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.0
+version: 2.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v4.1.0"
+appVersion: "v6.2.0"

--- a/charts/monk/templates/_helpers.tpl
+++ b/charts/monk/templates/_helpers.tpl
@@ -60,3 +60,49 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Container image reference.
+*/}}
+{{- define "monk.image" -}}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) -}}
+{{- end }}
+
+{{/*
+Shared envFrom for the init and main containers.
+*/}}
+{{- define "monk.envFrom" -}}
+- configMapRef:
+    name: {{ include "monk.fullname" . }}
+{{- if not .Values.existingSecret.enabled }}
+- secretRef:
+    name: {{ include "monk.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Environment variables when using an existing Secret.
+*/}}
+{{- define "monk.secretEnv" -}}
+{{- if .Values.existingSecret.enabled }}
+{{- if .Values.existingSecret.adminUsernameKey }}
+- name: LISTMONK_app__admin_username
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.existingSecret.secretName }}
+      key: {{ .Values.existingSecret.adminUsernameKey }}
+{{- end }}
+{{- if .Values.existingSecret.adminPasswordKey }}
+- name: LISTMONK_app__admin_password
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.existingSecret.secretName }}
+      key: {{ .Values.existingSecret.adminPasswordKey }}
+{{- end }}
+- name: LISTMONK_db__password
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.existingSecret.secretName }}
+      key: {{ .Values.existingSecret.databasePasswordKey }}
+{{- end }}
+{{- end }}

--- a/charts/monk/templates/deployment.yaml
+++ b/charts/monk/templates/deployment.yaml
@@ -27,62 +27,31 @@ spec:
       serviceAccountName: {{ include "monk.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.listmonk.freshInstall}}
       initContainers:
-        - name: init-db
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: ["./listmonk", "--install", "--yes"]
+        - name: db-check
+          image: {{ include "monk.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.existingSecret.enabled}}
+          command: ["/bin/sh", "-c"]
+          args:
+            - "./listmonk --install --idempotent --yes --config '' && ./listmonk --upgrade --yes --config ''"
+          {{- with include "monk.secretEnv" . | trim }}
           env:
-            - name: LISTMONK_app__admin_username
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.existingSecret.secretName }}
-                  key: {{ .Values.existingSecret.adminUsernameKey }}
-            - name: LISTMONK_app__admin_password
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.existingSecret.secretName }}
-                  key: {{ .Values.existingSecret.adminPasswordKey }}
-            - name: LISTMONK_db__password
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.existingSecret.secretName }}
-                  key: {{ .Values.existingSecret.databasePasswordKey }}
+            {{- . | nindent 12 }}
           {{- end }}
           envFrom:
-            - configMapRef:
-                name: {{ include "monk.fullname" . }}
-          {{- if not .Values.existingSecret.enabled }}
-            - secretRef:
-                name: {{ include "monk.fullname" . }}
-          {{- end }}
-          {{- end }}
+            {{- include "monk.envFrom" . | nindent 12 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          {{- if .Values.listmonk.upgrade}}
-          command: ["./listmonk", "--upgrade", "--yes"]
-          {{- end }}
+          image: {{ include "monk.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.existingSecret.enabled}}
+          {{- with include "monk.secretEnv" . | trim }}
           env:
-            - name: LISTMONK_db__password
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.existingSecret.secretName }}
-                  key: {{ .Values.existingSecret.databasePasswordKey }}
+            {{- . | nindent 12 }}
           {{- end }}
           envFrom:
-            - configMapRef:
-                name: {{ include "monk.fullname" . }}
-            {{- if not .Values.existingSecret.enabled }}
-            - secretRef:
-                name: {{ include "monk.fullname" . }}
-            {{- end }}
+            {{- include "monk.envFrom" . | nindent 12 }}
           ports:
             - name: http
               containerPort: 9090

--- a/charts/monk/values.yaml
+++ b/charts/monk/values.yaml
@@ -89,6 +89,9 @@ existingSecret:
   secretName: monk-secrets
   # this will overwrite the password in the database credentials section.
   databasePasswordKey: db_password
+  # Optional keys for first-time database install when using an existing secret.
+  # adminUsernameKey: admin_username
+  # adminPasswordKey: admin_password
 
 # To see the list of environment variables available go to https://listmonk.app/docs/configuration/#environment-variables
 env:
@@ -99,11 +102,6 @@ env:
 
 #listmonk app specific configurations
 listmonk:
-  # Changing this to true will delete and overwrite listmonk tables if they already exist in the database and that will reset the app state.
-  # If this is the first time you are running the app and didn't initialize the database leave it as true.
-  freshInstall: true
-  # This will run the upgrade command ./listmonk --upgrade
-  upgrade: false
   adminCredentials:
     username: "admin"
     password: "admin"


### PR DESCRIPTION
- Upgrade listmonk to v6.2.0
- Replace freshInstall/upgrade flags with an init container that runs idempotent install and upgrade on every deploy.
- Extract shared image, envFrom, and secret env logic into Helm helpers.